### PR TITLE
user/adminでログイン画面の分離

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -232,7 +232,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).


### PR DESCRIPTION
deviseがsign_upなどの画面で共通のものを使ってしまっていたので、userはuser用、adminはadmin用の画面を使用するように設定。

【/config/initializers/devise.rb】
config.scoped_views = true

・コメントアウトの解除
・false → true に変更

